### PR TITLE
Fix: Preventing full-width parallax Cover Image block rendering issue

### DIFF
--- a/inc/sass/common.scss
+++ b/inc/sass/common.scss
@@ -33,9 +33,7 @@ p + .alignwide {
     
     @include viewport(desktop) {
         width: 75vw;
-        margin-left: 50%;
-        -webkit-transform: translateX(-50%);
-        transform: translateX(-50%);
+        margin-left: calc( 50% - 75vw / 2 );
     }
     
     .edit-post-visual-editor & {
@@ -54,8 +52,7 @@ p + .alignwide {
 
 .alignfull {
     width: 100vw;
-    margin-left: 50%;
-    transform: translateX(-50%);
+    margin-left: calc( 50% - 50vw );
 
     .edit-post-visual-editor & {
         margin-bottom: 0;

--- a/inc/sass/style.scss
+++ b/inc/sass/style.scss
@@ -3651,9 +3651,7 @@ img.emoji {
 .has-wide-image .featured-video {
 	@include viewport(desktop) {
 		width: 90vw;
-		margin-left: 50%;
-		-webkit-transform: translateX(-50%);
-		transform: translateX(-50%);
+		margin-left: calc( 50% - 90vw / 2 );
 	}
 }
 


### PR DESCRIPTION
More info about the issue at https://codepen.io/webmandesign/post/gutenberg-full-width-alignment-in-wordpress-themes#where-are-the-other-block-examples-2

Also partially fixes #11