### PR TITLE
Prevent AMP validation error for echoed comment ID

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -109,7 +109,7 @@ function atomic_blocks_comment( $comment, $args, $depth ) { ?>
 				    <?php comment_author_link() ?>
 				</cite>
 
-				<a class="comment-time" href="<?php echo esc_url( get_comment_link( comment_ID() ) ) ?>"><?php printf( esc_html__( '%1$s at %2$s', 'atomic-blocks' ), get_comment_date(),  get_comment_time() ); ?></a><?php edit_comment_link( esc_html__( '(Edit)', 'atomic-blocks' ), '&nbsp;', '' ); ?>
+				<a class="comment-time" href="<?php echo esc_url( get_comment_link( get_comment_ID() ) ) ?>"><?php printf( esc_html__( '%1$s at %2$s', 'atomic-blocks' ), get_comment_date(),  get_comment_time() ); ?></a><?php edit_comment_link( esc_html__( '(Edit)', 'atomic-blocks' ), '&nbsp;', '' ); ?>
 			</div>
 
 			<div class="comment-content">


### PR DESCRIPTION
The ID needs to passed to get_comment_link but not echoed in this context.

Prevents an “Unknown error (INVALID_AMP_PROTOCOL)” AMP validation error.

Props @westonruter for the report via email.

![image (1)](https://user-images.githubusercontent.com/647669/73168437-1d8cf480-40fa-11ea-85fd-97a160e35ca4.png)
