### PR TITLE
Fitvids optional

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -243,7 +243,7 @@ function atomic_blocks_scripts() {
 	/**
 	 * Load fitvids javascript
 	 */
-	wp_enqueue_script( 'fitvids', get_template_directory_uri() . '/js/jquery.fitvids.js', array(), '1.1', true );
+	wp_enqueue_script( 'fitvids', get_template_directory_uri() . '/js/jquery.fitvids.js', array( 'jquery' ), '1.1', true );
 
 	/**
 	 * Localizes the atomic-blocks-js file

--- a/js/atomic-blocks.js
+++ b/js/atomic-blocks.js
@@ -62,7 +62,9 @@
 
 		// Fitvids
 		function fitVids() {
-			$('.post,.featured-image').fitVids();
+            if ($.isFunction($.fn.fitVids)) {
+			    $('.post,.featured-image').fitVids();
+            }
 		}
 		fitVids();
 


### PR DESCRIPTION
Two small enhancements to js fitvids:

- add a proper jquery dependency to wp_enqueue_script
- test if fitvits is loaded before call it

This allows you to disable fitvids completly if you want, or to use async script loader.